### PR TITLE
Handle schemas where the component type is "array"

### DIFF
--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -44,6 +44,13 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
     reduced = this.extract(root, root);
   } else if (component.properties) {
     reduced = this.mapPropertiesToExamples(component.properties, root);
+  } else if (component.type && component.type === "array" ) {
+    var minItems = component.minItems || 1;
+    var maxItems = component.maxItems || 1;
+    reduced = [];
+    _.range(_.random(minItems, maxItems)).forEach(function(i) {
+      reduced.push( this.extract(component.items, root) );
+    }.bind(this));
   }
   // Optionally merge in additional properties
   // @TODO: Determine if this is the right thing to do

--- a/test/fixtures/schema1.json
+++ b/test/fixtures/schema1.json
@@ -293,6 +293,28 @@
       "targetSchema": {
         "rel": "self"
       }
+    },
+    {
+      "title": "Get many foos",
+      "href": "/fixtures/foos",
+      "method": "GET",
+      "schema": {
+        "type": "object",
+        "description": "Queriable properties",
+        "properties": {
+          "foo": {
+            "$ref": "#/definitions/foo_prop"
+          }
+        }
+      },
+      "targetSchema": {
+        "type": "array",
+        "minItems": 2,
+        "maxItems": 5,
+        "items": {
+          "rel": "self"
+        }
+      }
     }
   ]
 }

--- a/test/transformer.js
+++ b/test/transformer.js
@@ -147,6 +147,34 @@ describe('Schema Transformer', function() {
         },
         plus_one: 'bar'
       });
+
+        it('should handle rel=self references as an array', function() {
+          var data = this.transformer.generateExample(this.schema1.links[3].targetSchema, this.schema1);
+          expect(data).to.be.an('array');
+          expect(data.length).to.be.gte(2);
+          expect(data.length).to.be.lte(5);
+          expect(data[0]).to.deep.equal({
+            id: 123,
+            foo: 'bar',
+            baz: 'boo',
+            array_prop: ['bar'],
+            boo: {
+              attribute_one: 'One'
+            },
+            nested_object: {
+              baz: 'boo',
+              foo: 'bar'
+            },
+            composite: {
+              attribute_one: 'One',
+              attribute_two: 'Two'
+            },
+            option: {
+              attribute_two: 'Two'
+            },
+            plus_one: 'bar'
+          });
+        });
     });
   });
 });


### PR DESCRIPTION
Currently, when a schema is of `"type": "array"`, the returned example is `{}`. If the schema is declared to be of `"type": "array"` and has an `"items"` key, the returned example should be an array containing items of that type.

ie:
```
"targetSchema": {
  "items": {
    "rel": "self"
    }
}
```
should return
```
[{
  // object matching the declared schema
}]
```