### PR TITLE
Add support for encType multipart/form-data

### DIFF
--- a/lib/curl.js
+++ b/lib/curl.js
@@ -18,9 +18,10 @@ module.exports = {
    * @param {String} [method=GET]
    * @param {Object} [headers]
    * @param {Object|Array} [data]
+   * @param {String} [encType=undefined]
    * @returns {String}
    */
-  generate: function(uri, method, headers, data) {
+  generate: function(uri, method, headers, data, encType) {
     var config = this.config;
     var flags = [];
     var str;
@@ -39,8 +40,12 @@ module.exports = {
       }, this);
     }
 
-    if (data && method.toLowerCase() !== 'get') {
-      flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
+    if (data) {
+      if (encType === 'multipart/form-data') {
+        flags.push(this.buildFlag('-form', this.formatForm(data), 5, '"'));
+      } else {
+        flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
+      }
     }
 
     return str + config.NEW_LINE + flags.join(config.NEW_LINE);
@@ -52,6 +57,14 @@ module.exports = {
    */
   formatData: function(data) {
     return this.formatter.format(data, null, 0);
+  },
+
+  /**
+   * @param {mixed} data
+   * @returns {String}
+   */
+  formatForm: function(data) {
+    return Object.keys(data).map(key => key + '=' + data[key]).join(';');
   },
 
   /**

--- a/lib/curl.js
+++ b/lib/curl.js
@@ -40,7 +40,7 @@ module.exports = {
       }, this);
     }
 
-    if (data) {
+    if (data && method.toLowerCase() !== 'get') {
       if (encType === 'multipart/form-data') {
         flags.push(this.buildFlag('-form', this.formatForm(data), 5, '"'));
       } else {

--- a/lib/curl.js
+++ b/lib/curl.js
@@ -64,7 +64,7 @@ module.exports = {
    * @returns {String}
    */
   formatForm: function(data) {
-    return Object.keys(data).map(key => key + '=' + data[key]).join(';');
+    return Object.keys(data).map(function(key) { return key + '=' + data[key] }).join(';');
   },
 
   /**

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -153,7 +153,7 @@ var buildCurl = function (link, schema, options) {
   }
   // @TODO: Make this better
   curl.formatter = JSONformatter;
-  return curl.generate(uri, link.method, headers, data);
+  return curl.generate(uri, link.method, headers, data, link.encType);
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-example-loader",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Webpack loader that transforms JSON HyperSchema (without $refs) into examples.",
   "main": "lib/loader.js",
   "scripts": {

--- a/test/curl.js
+++ b/test/curl.js
@@ -28,13 +28,12 @@ describe('cURL Helper', function() {
       expect(str).to.contain('My-Header: some value');
     });
 
-    it('should include request body data', function() {
+    it('should include request body data for undefined encType', function() {
       var str = curl.generate('https://api.example.com/url', 'POST', null, {
         my_key: 'my value'
       });
 
-      expect(str).to.contain('my_key');
-      expect(str).to.contain('my value');
+      expect(str).to.contain('--data \'{"my_key":"my value"}\'');
     });
 
     it('should add data as a query string for GET', function() {
@@ -44,6 +43,14 @@ describe('cURL Helper', function() {
       });
 
       expect(str).to.contain('"https://api.example.com/url?key1=value1&key2=value2"');
+    });
+
+    it('should add form for encType mutlipart', function() {
+      var str = curl.generate('https://api.example.com/url', 'POST', null, {
+        file: '@value'
+      }, 'multipart/form-data');
+
+      expect(str).to.contain('--form "file=@value"');
     });
   });
 


### PR DESCRIPTION
This:

```json
{
  "title": "Import DNS records",
  "href": "https://example.com",
  "method": "POST",
  "encType": "multipart/form-data",
  "schema": {
    "type": "object",
    "properties": {
      "file": {
        "type": "string",
          "media": {
            "type": "text/plain; charset=UTF-8"
          },
          "description": "BIND config to upload",
          "example": "@bind_config.txt"
        }
      }
    }
  }
},
```

will now generate this cURL example:

```bash
curl 'https://example.com' \
  --form "file=@bind_config.txt"
```
