### PR TITLE
Look for "required" required under "schema".

### DIFF
--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -80,7 +80,7 @@ var transformLink = function(schema, link, options) {
         html_id: _sanitizeHTMLID(schema.title + '-' + link.title),
         uri: buildHref(link.href, schema),
         curl: buildCurl(link, schema, options),
-        parameters: link.schema ? formatLinkParameters(link.schema, schema, link.required) : undefined,
+        parameters: link.schema ? formatLinkParameters(link.schema, schema) : undefined,
         response: link.targetSchema ? formatData(generateExample(link.targetSchema, schema)) : undefined
       }),
       ['schema', 'targetSchema']
@@ -184,11 +184,10 @@ var generateExample = function(component, root) {
  * @param {Object} schema - Link inputs
  * @returns {ObjectDefinition}
  */
-var formatLinkParameters = function(schema, root, required) {
+var formatLinkParameters = function(schema, root) {
   var baseSchema = root;
   if (schema.rel !== 'self') {
     baseSchema = schema;
-    baseSchema.required = required;
   }
   return generateObjectDefinition(baseSchema);
 };

--- a/test/fixtures/regression.json
+++ b/test/fixtures/regression.json
@@ -1,0 +1,25 @@
+{
+  "id": "/fixtures/regression",
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "title": "Regression Test Schema",
+  "links": [
+    {
+      "title": "Test bugs: required outside of schema",
+      "href": "/fixtures/regressions",
+      "method": "POST",
+      "required": [
+        "foo",
+        "baz"
+      ],
+      "schema": {
+        "required": ["boo"],
+        "properties": {
+          "foo": {"type": "boolean"},
+          "baz": {"type": "boolean"},
+          "boo": {"type": "boolean"}
+        }
+      }
+    }
+  ]
+}

--- a/test/object-definition.js
+++ b/test/object-definition.js
@@ -28,7 +28,7 @@ describe('Object Definition', function() {
   beforeEach(function() {
     this.definitionObjectKeys = ['title', 'description', 'all_props', 'required_props', 'optional_props', 'objects', 'example'];
     this.definition = new ObjectDefinition(this.schema1);
-    this.linkDefinition = new ObjectDefinition(this.schema1.links[2].schema);
+    this.linkParameters = new ObjectDefinition(this.schema1.links[2].schema);
   });
 
   describe('#constructor', function() {
@@ -74,16 +74,16 @@ describe('Object Definition', function() {
     });
 
     it('should return required properites when defined', function() {
-      expect(this.linkDefinition.required_props).to.have.members(['foo', 'baz']);
+      expect(this.linkParameters.required_props).to.have.members(['foo', 'baz']);
     });
 
     it('should include all properties found', function() {
-      expect(this.linkDefinition.all_props).to.have.keys(['foo', 'baz', 'boo']);
+      expect(this.linkParameters.all_props).to.have.keys(['foo', 'baz', 'boo']);
     });
 
     it('should only include optional properties', function() {
-      expect(this.linkDefinition.optional_props).to.have.members(['boo']);
-      expect(this.linkDefinition.optional_props).to.not.have.members(['foo', 'baz']);
+      expect(this.linkParameters.optional_props).to.have.members(['boo']);
+      expect(this.linkParameters.optional_props).to.not.have.members(['foo', 'baz']);
     });
 
     it('should merge allOf references together', function() {

--- a/test/regression.js
+++ b/test/regression.js
@@ -1,0 +1,46 @@
+'use strict';
+/* globals: describe, it */
+
+var expect = require('chai').expect;
+var transformer = require('../lib/transformer');
+var regression = require('./fixtures/regression.json');
+var ObjectDefinition = require('../lib/object-definition');
+var _ = require('lodash');
+
+/** @name describe @function */
+/** @name it @function */
+/** @name before @function */
+/** @name after @function */
+/** @name beforeEach @function */
+/** @name afterEach @function */
+
+describe('Schema Transformer Regression', function() {
+  // @TODO Figure out a better way isolate these tests
+  before(function() {
+    this.regression = _.cloneDeep(regression);
+  });
+
+  describe('#transformLinkRegression', function() {
+    beforeEach(function() {
+      this.link = transformer.transformLink(this.regression, this.regression.links[0]);
+    });
+
+    it('should not copy a link "required" into parameters', function() {
+      expect(this.link.parameters).to.not.have.property('required');
+    });
+
+    it('should have the required property from inside schema', function() {
+      expect(this.link.parameters.required_props).to.have.members(['boo']);
+      expect(this.link.parameters.required_props).to.not.have.members(['foo', 'baz']);
+    });
+
+    it('should have optional properties based on the inner required', function() {
+      expect(this.link.parameters.optional_props).to.have.members(['foo', 'baz']);
+      expect(this.link.parameters.optional_props).to.not.have.members(['boo']);
+    });
+
+    it('should still see all parameters', function() {
+      expect(this.link.parameters.all_props).to.have.keys(['foo', 'baz', 'boo']);
+    });
+  });
+});


### PR DESCRIPTION
We had been looking for "required" at the LDO level, and
copying it into the parameters object (which would blank
out any "required" present inside the top level of "schema").

This removes that copy and adds a regression test for the
old behavior.  It also renames a test variable to be more
clear (a linkDefinition would be expected to be an LDO,
which made that test appear to pass by looking at an LDO
when the fixture actually had "required" inside of "schema",
which was confusing when debugging the issue).