### PR TITLE
Remove no-longer-needed "ID" hack.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ var transformedSchema = require('./schema.json');
 
 ```json
 {
-  "id": "/product",
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "id": "https://api.example.com/product",
+  "$schema": "http://json-schema.org/draft-04/hyper-schema#",
   "title": "Product",
   "description": "A product available for sale in a store",
   "type": "object",
@@ -68,12 +68,12 @@ var transformedSchema = require('./schema.json');
     }
   },
   "required": [
-    "ID",
+    "id",
     "name",
     "description"
   ],
   "properties": {
-    "ID": {
+    "id": {
       "type": "string",
       "description": "Product SKU",
       "example": "ABC-123"
@@ -132,7 +132,7 @@ var transformedSchema = require('./schema.json');
 
 ```json
 {
-  "id": "/product",
+  "id": "https://api.example.com/product",
   "title": "Product",
   "description": "A product available for sale in a store",
   "type": "object",
@@ -181,7 +181,7 @@ var transformedSchema = require('./schema.json');
   "object_definition": {
     "_formatter": {},
     "all_props": {
-      "ID": {
+      "id": {
         "type": "string",
         "example": "\"ABC-123\"",
         "description": "Product SKU"
@@ -198,7 +198,7 @@ var transformedSchema = require('./schema.json');
       }
     },
     "required_props": [
-      "ID",
+      "id",
       "name",
       "description"
     ],

--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -99,13 +99,7 @@ ExampleDataExtractor.prototype.mapPropertiesToExamples = function(props, schema)
         return _.extend(accumulator, this.extract(item, schema));
       }, example || {}, this);
     }
-    // Special case for ID. This is done mostly because
-    // the parser gets confused when declaring "id" as a property of an object,
-    // because it wants to resolve it as reference to another schema.
-    // The current solution is to declare ids as "ID" for the data object in the schema
-    // See: http://json-schema.org/latest/json-schema-core.html#anchor27
-    // Override with `preserveCase` in the options
-    properties[propName === 'ID' ? propName.toLowerCase() : propName] = example;
+    properties[propName] = example;
   }, {}, this);
 };
 

--- a/test/example-data-extractor.js
+++ b/test/example-data-extractor.js
@@ -44,7 +44,6 @@ describe('Example Data Extractor', function() {
       this.example = extractor.mapPropertiesToExamples(this.schema1.properties, this.schema1);
       // Makes tests easier to write
       this.properties = _.keys(this.schema1.properties);
-      this.properties[this.properties.indexOf('ID')] = 'id';
     });
 
     it('should build example values from the given property definitions', function() {
@@ -76,8 +75,11 @@ describe('Example Data Extractor', function() {
       expect(this.example.nested_object).to.have.keys(_.keys(this.schema2.properties));
     });
 
-    it('should lowercase ID property references', function() {
-      expect(this.example).to.not.contain.key('ID');
+    it('should NOT lowercase ID property references', function() {
+      expect(this.example).to.contain.key('ID');
+    });
+
+    it('should handle lowercase id properties', function() {
       expect(this.example).to.contain.key('id');
     });
 

--- a/test/fixtures/schema1.json
+++ b/test/fixtures/schema1.json
@@ -44,10 +44,15 @@
     }
   },
   "properties": {
-    "ID": {
+    "id": {
       "type": "number",
       "description": "Foo ID",
       "example": 123
+    },
+    "ID": {
+      "type": "string",
+      "description": "tests that ID is no longer a special case",
+      "example": "something"
     },
     "foo": {
       "type": "string",

--- a/test/transformer.js
+++ b/test/transformer.js
@@ -128,6 +128,7 @@ describe('Schema Transformer', function() {
       expect(data).to.be.an('object');
       expect(data).to.deep.equal({
         id: 123,
+        ID: 'something',
         foo: 'bar',
         baz: 'boo',
         array_prop: ['bar'],


### PR DESCRIPTION
Fixes cloudflare/doca#11

At some point, some library somewhere would incorrectly treat
properties called "id" as JSON Schema "id" keywords, which was
never correct behavior.  We compensated for it by recognizing
"ID" and downcasing it.  This is no longer needed.

The comment mentioned a "preserveCase" option but I cannot find
any other mention of it in the code or tests, so perhaps that
was never implemented.