### PR TITLE
Use a valid "oneOf" in the fixture.

### DIFF
--- a/test/example-data-extractor.js
+++ b/test/example-data-extractor.js
@@ -59,7 +59,7 @@ describe('Example Data Extractor', function() {
       expect(this.example.composite).to.be.an('object');
       expect(this.example.composite).to.have.keys(['attribute_one', 'attribute_two']);
       expect(this.example.composite).to.have.property('attribute_one').that.equals('One');
-      expect(this.example.composite).to.have.property('attribute_two').that.equals('Two');
+      expect(this.example.composite).to.have.property('attribute_two').that.equals(2);
     });
 
     it('should resolve rel=self references', function() {
@@ -86,7 +86,7 @@ describe('Example Data Extractor', function() {
     });
 
     it('should resolve the first anyOf reference', function() {
-      expect(this.example.option).to.have.property('attribute_two').that.equals('Two');
+      expect(this.example.option).to.have.property('attribute_two').that.equals(2);
     });
 
     it('should resolve array references', function() {

--- a/test/fixtures/schema1.json
+++ b/test/fixtures/schema1.json
@@ -36,9 +36,9 @@
       "description": "Object 2",
       "properties": {
         "attribute_two": {
-          "type": "string",
+          "type": "number",
           "description": "Attribute 2",
-          "example": "Two"
+          "example": 2
         }
       }
     }
@@ -78,9 +78,9 @@
           "description": "Object 2",
           "properties": {
             "attribute_two": {
-              "type": "string",
+              "type": "number",
               "description": "Attribute 2",
-              "example": "Two"
+              "example": 2
             }
           }
         }
@@ -94,9 +94,9 @@
           "description": "Object 2",
           "properties": {
             "attribute_two": {
-              "type": "string",
+              "type": "number",
               "description": "Attribute 2",
-              "example": "Two"
+              "example": 2
             }
           }
         },
@@ -131,9 +131,9 @@
           "description": "Object 2",
           "properties": {
             "attribute_two": {
-              "type": "string",
+              "type": "number",
               "description": "Attribute 2",
-              "example": "Two"
+              "example": 2
             }
           }
         }
@@ -280,9 +280,9 @@
                 "description": "Object 2",
                 "properties": {
                   "attribute_two": {
-                    "type": "string",
+                    "type": "number",
                     "description": "Attribute 2",
-                    "example": "Two"
+                    "example": 2
                   }
                 }
               }

--- a/test/transformer.js
+++ b/test/transformer.js
@@ -118,7 +118,7 @@ describe('Schema Transformer', function() {
       });
       expect(this.example.composite).to.eql({
         attribute_one: 'One',
-        attribute_two: 'Two'
+        attribute_two: 2
       });
       expect(this.example.nested_object).to.not.be.empty;
     });
@@ -140,10 +140,10 @@ describe('Schema Transformer', function() {
         },
         composite: {
           attribute_one: 'One',
-          attribute_two: 'Two'
+          attribute_two: 2
         },
         option: {
-          attribute_two: 'Two'
+          attribute_two: 2
         },
         plus_one: 'bar'
       });
@@ -167,10 +167,10 @@ describe('Schema Transformer', function() {
             },
             composite: {
               attribute_one: 'One',
-              attribute_two: 'Two'
+              attribute_two: 2
             },
             option: {
-              attribute_two: 'Two'
+              attribute_two: 2
             },
             plus_one: 'bar'
           });


### PR DESCRIPTION
A "oneOf" where both branches are just declared to be strings can
never validate successfully as any string will validate against
both branches, and nothing else will validate against either.

This doesn't affect anything in the current tests, but if
anyone tried to do a test involving validation (such as validating
the constructed example), it would always fail.