### PR TITLE
Track root oneOf vs anyOf usage.

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,8 @@ As you can see, some properties are missing and some are added/updated. Removed 
   - all_props : *object* - all required properties (object where keys = prop names)
   - required_props : *array* - list of keys in all_props
   - optional_props : *array* - list of keys in all_props
-  - objects : *array* - nested object_definition (in case when oneOf/anyOf/allOf are used)
+  - objects : *array* - nested object_definition (in case when oneOf/anyOf are used)
+  - which_of : *string* - the name of the property used for objects, if any
   - example : *string* - stringified example of the whole schema object
 
 **At the link level:**

--- a/lib/curl.js
+++ b/lib/curl.js
@@ -48,7 +48,10 @@ module.exports = {
       }
     }
 
-    return str + config.NEW_LINE + flags.join(config.NEW_LINE);
+    if (flags.length) {
+      return str + config.NEW_LINE + flags.join(config.NEW_LINE);
+    }
+    return str;
   },
 
   /**

--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -25,6 +25,7 @@ var ObjectDefinition = function(object, options) {
  *   required_props: Array,
  *   optional_props: Array,
  *   objects: Array,
+ *   which_of: string,
  *   example: string
  * }}
  */
@@ -60,6 +61,7 @@ ObjectDefinition.prototype.build = function(object) {
   } else if (_.isArray(object.oneOf) || _.isArray(object.anyOf)) {
     var objects = object.oneOf || object.anyOf;
     self.objects = _.map(objects, this.build, this);
+    self.which_of = object.oneOf ? 'oneOf' : 'anyOf'
 
   } else if (_.isPlainObject(object.properties)) {
     _.extend(self.all_props, this.defineProperties(object.properties));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-example-loader",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Webpack loader that transforms JSON HyperSchema (without $refs) into examples.",
   "main": "lib/loader.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-example-loader",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Webpack loader that transforms JSON HyperSchema (without $refs) into examples.",
   "main": "lib/loader.js",
   "scripts": {

--- a/test/curl.js
+++ b/test/curl.js
@@ -13,8 +13,11 @@ var curl = require('../lib/curl');
 
 describe('cURL Helper', function() {
   describe('#generate', function() {
-    it('should return a string', function() {
-      expect(curl.generate('https://api.example.com/url')).to.be.a('string');
+    it('should return a string ending in the url', function() {
+      var url = 'https://api.example.com/url';
+      var curlString = curl.generate(url);
+      expect(curlString).to.be.a('string');
+      expect(curlString.endsWith(url + '"')).to.be.true;
     });
 
     it('should include the HTTP method', function() {

--- a/test/object-definition.js
+++ b/test/object-definition.js
@@ -103,6 +103,7 @@ describe('Object Definition', function() {
       expect(result.objects).to.have.length(2);
       expect(result.objects[0], 'first object').to.have.keys(this.definitionObjectKeys);
       expect(result.objects[1], 'second object').to.have.keys(this.definitionObjectKeys);
+      expect(result.which_of).to.equal('oneOf');
     });
 
     it('should build an array of definition objects for anyOf references', function() {
@@ -117,6 +118,7 @@ describe('Object Definition', function() {
       expect(result.objects).to.have.length(2);
       expect(result.objects[0], 'first object').to.have.keys(this.definitionObjectKeys);
       expect(result.objects[1], 'second object').to.have.keys(this.definitionObjectKeys);
+      expect(result.which_of).to.equal('anyOf');
     });
 
     it('should include additional properties in all props when defined', function() {


### PR DESCRIPTION
This is a quick and admittedly kind of hacky fix for information
I need in the theme.  It's off in a branch that may or may not
be merged to master (which has other changes on it that are
not entirely compatible and shouldn't be published yet).

For the root object definition, we put the oneOf/anyOf contents
in schema.objects, but remove the keywords and did not record which
keyword was used.  This makes it impossible to calculate the schema
pointer for analytics purposes.

Store the keywords so we can access it in the theme.

Also, take "allOf" out of that one spot in the README as it is handled
completely differently from "oneOf" and "anyOf" and does not use
the "objects" data member.