### PR TITLE
Avoid a trailing slash on a singl-line curl

### DIFF
--- a/lib/curl.js
+++ b/lib/curl.js
@@ -48,7 +48,10 @@ module.exports = {
       }
     }
 
-    return str + config.NEW_LINE + flags.join(config.NEW_LINE);
+    if (flags.length) {
+      return str + config.NEW_LINE + flags.join(config.NEW_LINE);
+    }
+    return str;
   },
 
   /**

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-example-loader",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Webpack loader that transforms JSON HyperSchema (without $refs) into examples.",
   "main": "lib/loader.js",
   "scripts": {

--- a/test/curl.js
+++ b/test/curl.js
@@ -13,8 +13,11 @@ var curl = require('../lib/curl');
 
 describe('cURL Helper', function() {
   describe('#generate', function() {
-    it('should return a string', function() {
-      expect(curl.generate('https://api.example.com/url')).to.be.a('string');
+    it('should return a string ending in the url', function() {
+      var url = 'https://api.example.com/url';
+      var curlString = curl.generate(url);
+      expect(curlString).to.be.a('string');
+      expect(curlString.endsWith(url + '"')).to.be.true;
     });
 
     it('should include the HTTP method', function() {


### PR DESCRIPTION
We were still appending the \ even when there were no header or data lines.