### PR TITLE
Non-standard additionalProperties -> extraProperties

### DIFF
--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -52,10 +52,10 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
       reduced.push( this.extract(component.items, root) );
     }.bind(this));
   }
-  // Optionally merge in additional properties
+  // Optionally merge in extra properties
   // @TODO: Determine if this is the right thing to do
-  if (_.has(component, 'additionalProperties') && _.get(component, 'generator.includeAdditionalProperties')) {
-    _.extend(reduced, this.mapPropertiesToExamples(component.additionalProperties, root));
+  if (_.has(component, 'extraProperties') && _.get(component, 'generator.includeExtraProperties')) {
+    _.extend(reduced, this.mapPropertiesToExamples(component.extraProperties, root));
   }
 
   return reduced;

--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -66,14 +66,14 @@ ObjectDefinition.prototype.build = function(object) {
   } else if (_.isPlainObject(object.properties)) {
     _.extend(self.all_props, this.defineProperties(object.properties));
 
-    if (_.isPlainObject(object.additionalProperties)) {
-      _.extend(self.all_props, this.defineProperties(object.additionalProperties));
+    if (_.isPlainObject(object.extraProperties)) {
+      _.extend(self.all_props, this.defineProperties(object.extraProperties));
     }
   }
 
-  // Allow oneOf/anyOf/allOf reference to also include additional properties
-  if (_.isPlainObject(object.additionalProperties)) {
-    var addtlProps = this.defineProperties(object.additionalProperties);
+  // Allow oneOf/anyOf/allOf reference to also include extra properties
+  if (_.isPlainObject(object.extraProperties)) {
+    var addtlProps = this.defineProperties(object.extraProperties);
     _.each(self.objects, function(obj) {
       _.extend(obj.all_props, addtlProps);
     });

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -33,7 +33,6 @@ var transformSchema = function(schema, options) {
       object_definition: generateObjectDefinition(schema)
     }), [
       'properties',
-      'additionalProperties',
       'definitions',
       'allOf',
       'anyOf',

--- a/test/example-data-extractor.js
+++ b/test/example-data-extractor.js
@@ -125,7 +125,7 @@ describe('Example Data Extractor', function() {
       }, this.schema1)).to.be.an('object');
     });
 
-    it('should include additional properties', function() {
+    it('should include extra properties', function() {
       expect(this.example).to.have.property('plus_one').that.is.not.empty;
     });
   });

--- a/test/fixtures/schema1.json
+++ b/test/fixtures/schema1.json
@@ -216,7 +216,7 @@
       }
     }
   },
-  "additionalProperties": {
+  "extraProperties": {
     "plus_one": {
       "type": "string",
       "description": "Foo property",
@@ -224,7 +224,7 @@
     }
   },
   "generator": {
-    "includeAdditionalProperties": true
+    "includeExtraProperties": true
   },
   "links": [
     {

--- a/test/object-definition.js
+++ b/test/object-definition.js
@@ -121,7 +121,7 @@ describe('Object Definition', function() {
       expect(result.which_of).to.equal('anyOf');
     });
 
-    it('should include additional properties in all props when defined', function() {
+    it('should include extra properties in all props when defined', function() {
       expect(this.definition.all_props).to.contain.key('plus_one');
     });
 


### PR DESCRIPTION
This partially addresses cloudflare/doca#52

We have not been using "additionalProperties" correctly.
The full fix is non-trivial and will probably have to wait
for a larger refactoring.

For now, rename the keyword for this behavior to "extraProperties"
so that we can keep it without actively violating the spec.

All unit tests pass.