### PR TITLE
Numerous array and object features

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
   - 'stable'
   - '4'
-  - '0.12'
 script: 'npm run coverage'
 after_success:
   - npm install -g codeclimate-test-reporter

--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -21,6 +21,14 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
   if (!component) {
     throw new ReferenceError('No schema received to generate example data');
   }
+
+  if (component.example) {
+    // Don't build an example if we are given one directly.  This allows
+    // overriding for complex schemas that can't easily be handled by
+    // the example roll-up process.
+    return component.example;
+  }
+
   // If the schema defines an ID, change scope so all local references as resolved
   // relative to the schema with the closest ID
   if (component.id) {
@@ -43,23 +51,64 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
     // Used in the Hyper-Schema spec
     reduced = this.extract(root, root);
   } else if (component.properties) {
+    // TODO: We do not roll up patternProperties and additionalProperties
+    //       because generating property names is hard.  Schema authors
+    //       should include a full object-level example for subschemas
+    //       using those properties.
     reduced = this.mapPropertiesToExamples(component.properties, root);
-  } else if (component.type && component.type === "array" ) {
-    var minItems = component.minItems || 1;
-    var maxItems = component.maxItems || 1;
-    reduced = [];
-    _.range(_.random(minItems, maxItems)).forEach(function(i) {
-      reduced.push( this.extract(component.items, root) );
-    }.bind(this));
+  } else if (component.items) {
+    if (_.isArray(component.items)) {
+      reduced = this.mapItemsToExamples(component, root);
+    } else {
+      // Don't show more than 2 examples unless minItems > 2.
+      // TODO: This won't work if uniqueItems is true.  Schema authors should
+      //       provide a full array example in such cases.
+      reduced = [];
+      var minItems = component.minItems || 1;
+      _.range(0, _.max([minItems, 2])).forEach(function(i) {
+        reduced.push(this.extract(component.items, root));
+      }.bind(this));
+    }
   }
   // Optionally merge in extra properties
-  // @TODO: Determine if this is the right thing to do
   if (_.has(component, 'extraProperties') && _.get(component, 'generator.includeExtraProperties')) {
     _.extend(reduced, this.mapPropertiesToExamples(component.extraProperties, root));
   }
 
   return reduced;
 };
+
+/**
+ * Extracts a tuple-style items example, with or without additionalItems
+ *
+ * @param {Object} component - Schema containing items
+ * @param {Object} root - Root schema containing array_schema
+ * @returns {*}
+ */
+ExampleDataExtractor.prototype.mapItemsToExamples = function(component,
+                                                             root) {
+  var minItems = component.minItems || 1;
+  var maxItems = component.maxItems || component.items.length + 1;
+  var reduced = _.map(component.items, item => this.extract(item, root));
+
+  // Only show additionalItems if they can be used.
+  // There are situations in which it might not be an error to have
+  // an unusable schema (because maxItems < items.length), so don't
+  // raise an error.  This can occur in complex re-use cases involving
+  // negated schemas.
+  // Also, ignore boolean additionalItems for examples.
+  var numAddlItems = _.max([
+    _.max([minItems - component.items.length, 0]),
+    _.max([maxItems - component.items.length, 0])
+  ]);
+  if (numAddlItems > 0 && _.isPlainObject(component.additionalItems)) {
+    var addlExample = this.extract(component.additionalItems, root);
+    _.range(0, numAddlItems).forEach(function(i) {
+      reduced.push(addlExample);
+    }.bind(this));
+  }
+  return reduced;
+}
 
 /**
  * Maps a `properties` definition to an object containing example values
@@ -82,11 +131,15 @@ ExampleDataExtractor.prototype.mapPropertiesToExamples = function(props, schema)
 
     if (propConfig.rel === 'self') {
       example = this.extract(schema, schema);
-    } else if (propConfig.type === 'array' && propConfig.items && !example) {
-      if (propConfig.items.example) {
-        example = [propConfig.items.example];
+    } else if (propConfig.items && !example) {
+      if (_.isArray(propConfig.items)) {
+        example = this.mapItemsToExamples(propConfig, schema);
       } else {
-        example = [this.extract(propConfig.items, schema)];
+        if (propConfig.items.example) {
+          example = [propConfig.items.example];
+        } else {
+          example = [this.extract(propConfig.items, schema)];
+        }
       }
     } else if (propConfig.id && !example) {
       example = this.extract(propConfig, propConfig);

--- a/lib/object-definition.js
+++ b/lib/object-definition.js
@@ -44,7 +44,7 @@ ObjectDefinition.prototype.build = function(object) {
     example: ''
   }
   
-  if (object.type === 'array') {
+  if (object.items) {
     object = object.items;
   }
 
@@ -78,6 +78,8 @@ ObjectDefinition.prototype.build = function(object) {
       _.extend(obj.all_props, addtlProps);
     });
   }
+
+  this.handlePassthrough(self, object);
 
   self.title = object.title;
   self.description = object.description;
@@ -129,14 +131,59 @@ ObjectDefinition.prototype.defineProperty = function(property) {
     var key = property.oneOf ? 'oneOf' : 'anyOf';
     definition[key] = _.map(property.oneOf || property.anyOf, this.build, this);
 
-  // If the property value is an object and has its own properties,
-  // make them available to the definition
-  } else if (property.properties) {
-    definition.properties = this.defineProperties(property.properties);
+  // If the property value is an object or array, recurse into subschemas
+  // Note that defineProperty() handles a schema, whether it is a property
+  // schema or something else (like a schema for array items).
+  } else {
+    if (property.properties) {
+      definition.properties = this.defineProperties(property.properties);
+    }
+
+    if (property.items) {
+      if (_.isArray(property.items)) {
+        definition.items = _.map(property.items, this.defineProperty, this);
+      } else {
+        definition.items = this.defineProperty(property.items);
+      }
+    }
+
+    if (property.additionalItems) {
+      definition.additionalItems =
+          this.defineProperty(property.additionalItems);
+    } else if (property.additionalItems === false) {
+      definition.additionalitems = property.additionalItems;
+    }
   }
+
+  this.handlePassthrough(definition, property);
 
   return _.defaults(definition, property);
 };
+
+/**
+ * Handle simple definition recursion for properties that
+ * we don't actively support.
+ */
+ObjectDefinition.prototype.handlePassthrough = function(definition, property) {
+
+  if (property.patternProperties) {
+    definition.patternProperties =
+      this.defineProperties(property.patternProperties);
+  }
+
+  if (property.additionalProperties) {
+    definition.additionalProperties =
+      this.defineProperty(property.additionalProperties);
+  } else if (property.additionalProperties === false) {
+      definition.additionalProperties = property.additionalProperties;
+  }
+
+  // We generally do not handle "not", but pass it through in case
+  // a theme wants to do something with it.
+  if (property.not) {
+    definition.not = this.defineProperty(property.not);
+  }
+}
 
 /**
  *

--- a/test/fixtures/schema1.json
+++ b/test/fixtures/schema1.json
@@ -214,6 +214,60 @@
         "description": "Foo property",
         "example": "bar"
       }
+    },
+    "tuple_prop": {
+      "type": "array",
+      "description": "A pair of things",
+      "items": [
+        {
+          "type": "integer",
+          "example": 42
+        },
+        {
+          "type": "string",
+          "example": "answer"
+        }
+      ],
+      "additionalItems": false
+    },
+    "tuple_prop_additional": {
+      "type": "array",
+      "description": "One special, the rest the same",
+      "items": [
+        {
+          "type": "boolean",
+          "example": true
+        }
+      ],
+      "additionalItems": {
+        "type": "number",
+        "example": 3.14
+      },
+      "minItems": 3
+    },
+    "pass_through_keywords": {
+      "type": "object",
+      "description": "Keywords for which we do not create examples, with an example outside of those keywords.",
+      "patternProperties": {
+        "^[a-f]+$": {
+          "type": "integer",
+          "example": 5
+        }
+      },
+      "additionalProperties": {
+        "type": "string",
+        "example": "ex"
+      },
+      "example": {
+        "a": 5,
+        "x": "ex"
+      }
+    }
+  },
+  "not": {
+    "description": "Tests that 'not' is passed through",
+    "properties": {
+      "abc": {}
     }
   },
   "extraProperties": {
@@ -314,7 +368,7 @@
       },
       "targetSchema": {
         "type": "array",
-        "minItems": 2,
+        "minItems": 3,
         "maxItems": 5,
         "items": {
           "rel": "self"

--- a/test/object-definition.js
+++ b/test/object-definition.js
@@ -135,6 +135,9 @@ describe('Object Definition', function() {
       expect(this.definition.example).to.contain('composite');
       expect(this.definition.example).to.contain('nested_object');
       expect(this.definition.example).to.contain('array_prop');
+      expect(this.definition.example).to.contain('tuple_prop');
+      expect(this.definition.example).to.contain('tuple_prop_additional');
+      expect(this.definition.example).to.contain('pass_through_keywords');
       expect(this.definition.example).to.contain('plus_one');
     });
   });
@@ -148,6 +151,15 @@ describe('Object Definition', function() {
   describe('#defineProperty', function() {
     it('should return an object', function() {
       expect(this.definition.defineProperty({})).to.be.an('object');
+    });
+
+    it('should include pass-through keywords', function() {
+      expect(this.definition).to.have.property('not');
+
+      var all_props = this.definition.all_props;
+      expect(all_props).to.have.property('pass_through_keywords');
+      expect(all_props.pass_through_keywords).to.have.property('additionalProperties')
+      expect(all_props.pass_through_keywords).to.have.property('patternProperties')
     });
 
     it('should always include a type defined by the property', function() {
@@ -249,6 +261,16 @@ describe('Object Definition', function() {
       expect(example).to.not.equal('[]');
       expect(example).to.contain('[');
       expect(example).to.contain(']');
+    });
+
+    it('should detect if the property is a tuple', function() {
+      var example = this.definition.getExampleFromProperty(this.schema1.properties.tuple_prop);
+      expect(example).to.equal('[\n  42,\n  "answer"\n]');
+    });
+
+    it('should handle additionalItems for tuples', function() {
+      var example = this.definition.getExampleFromProperty(this.schema1.properties.tuple_prop_additional);
+      expect(example).to.equal('[\n  true,\n  3.14,\n  3.14\n]');
     });
   });
 });

--- a/test/transformer.js
+++ b/test/transformer.js
@@ -132,6 +132,9 @@ describe('Schema Transformer', function() {
         foo: 'bar',
         baz: 'boo',
         array_prop: ['bar'],
+        tuple_prop: [42, "answer"],
+        tuple_prop_additional: [true, 3.14, 3.14],
+        pass_through_keywords: {"a": 5, "x": "ex"},
         boo: {
           attribute_one: 'One'
         },
@@ -148,34 +151,37 @@ describe('Schema Transformer', function() {
         },
         plus_one: 'bar'
       });
+    });
 
-        it('should handle rel=self references as an array', function() {
-          var data = this.transformer.generateExample(this.schema1.links[3].targetSchema, this.schema1);
-          expect(data).to.be.an('array');
-          expect(data.length).to.be.gte(2);
-          expect(data.length).to.be.lte(5);
-          expect(data[0]).to.deep.equal({
-            id: 123,
-            foo: 'bar',
-            baz: 'boo',
-            array_prop: ['bar'],
-            boo: {
-              attribute_one: 'One'
-            },
-            nested_object: {
-              baz: 'boo',
-              foo: 'bar'
-            },
-            composite: {
-              attribute_one: 'One',
-              attribute_two: 2
-            },
-            option: {
-              attribute_two: 2
-            },
-            plus_one: 'bar'
-          });
-        });
+    it('should handle rel=self references as an array', function() {
+      var data = transformer.generateExample(this.schema1.links[3].targetSchema, this.schema1);
+      expect(data).to.be.an('array');
+      expect(data.length).to.equal(3);
+      expect(data[0]).to.deep.equal({
+        id: 123,
+        ID: 'something',
+        foo: 'bar',
+        baz: 'boo',
+        array_prop: ['bar'],
+        tuple_prop: [42, "answer"],
+        tuple_prop_additional: [true, 3.14, 3.14],
+        pass_through_keywords: {"a": 5, "x": "ex"},
+        boo: {
+          attribute_one: 'One'
+        },
+        nested_object: {
+          baz: 'boo',
+          foo: 'bar'
+        },
+        composite: {
+          attribute_one: 'One',
+          attribute_two: 2
+        },
+        option: {
+          attribute_two: 2
+        },
+        plus_one: 'bar'
+      });
     });
   });
 });


### PR DESCRIPTION
* Allow "items" without setting type to "array"
* Support tuple form of "items", with or without "additionalItems"
* Pass "not", "additionalProperties", and "patternProperties' through
* Allow overriding example roll-up at the top level.

This is all a bit hacky, but we're going to revamp this code
thoroughly in the near future.  This level of support significantly
reduces the number of caveats we need to document for JSON Schema
draft-04 support.

Also, drop obsolete Node support from Travis config.