### PR TITLE
Namespace cloudflare/doca exension keywords

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
   - 'stable'
-  - '4'
-  - '0.12'
 script: 'npm run coverage'
 after_success:
   - npm install -g codeclimate-test-reporter

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v3.0.0
+
+* The non-standard usage of "rel": "self" has been changed to a new
+  extension keyword, "cfRecurse": "".  The "" is technically a plain
+  (not URI fragment encoded) JSON Pointer (specifically the root pointer).
+  Currently, only the root pointer is supported, keeping parity with
+  the old "rel": "self" post-"$ref"-resolution recursion.
+
+* The non-standard "requestHeaders" and "private" fields have been
+  namespaced as "cfRequestHeaders" and "cfPrivate" respectively.
+
+* Fields that start with "\_\_" are no longer treated as private.
+  Use "cfPrivate" to flag private fields.
+
+* Two additional custom keywords have **not** been changed:
+  "extraProperties" will get a more extensive reworking in the
+  nearish future, and "example" becomes "examples" in the draft-06
+  of JSON Schema so it seems pointlessly disruptive to put a "cf" on it.
+
 ## v2.0.0
 
 * `"required"` and `"type"` now behave normally with the LDO's `"schema"` (previously they needed to be outside of `"schema"` at the top of the LDO)

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var throwError = function(e, msg) {
+  var err = new Error(msg + ': ' + e.message);
+  err.stack = e.stack;
+  throw err;
+};
+
+module.exports = {
+  throwError: throwError,
+  INVALID_RECURSE_TARGET:
+    '"cfRecurse" currently only supports "" (the empty string) as a target'
+};

--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -79,8 +79,7 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
 ExampleDataExtractor.prototype.mapPropertiesToExamples = function(props, schema) {
   return _.transform(props, function(properties, propConfig, propName) {
     // Allow opt-ing out of generating example data
-    // TODO: Drop __ once certain we are not using it.
-    if (_.startsWith(propName, '__') || propConfig.private) {
+    if (propConfig.cfPrivate) {
       return properties;
     }
 

--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const errors = require('./errors');
+
+
 var _ = require('lodash');
 /**
  * @class ExampleDataExtractor
@@ -38,9 +41,11 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
   } else if (component.anyOf) {
     // Select the first item to build an example object from
     reduced = this.extract(component.anyOf[0], root);
-  } else if (component.rel === 'self') {
+  } else if (component.cfRecurse !== undefined) {
     // Special case where the component is referencing the context schema.
-    // Used in the Hyper-Schema spec
+    if (component.cfRecurse !== '') {
+      throw new ReferenceError(errors.RECURSE_TARGET);
+    }
     reduced = this.extract(root, root);
   } else if (component.properties) {
     reduced = this.mapPropertiesToExamples(component.properties, root);
@@ -74,13 +79,17 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
 ExampleDataExtractor.prototype.mapPropertiesToExamples = function(props, schema) {
   return _.transform(props, function(properties, propConfig, propName) {
     // Allow opt-ing out of generating example data
+    // TODO: Drop __ once certain we are not using it.
     if (_.startsWith(propName, '__') || propConfig.private) {
       return properties;
     }
 
     var example = this.getExampleDataFromItem(propConfig);
 
-    if (propConfig.rel === 'self') {
+    if (propConfig.cfRecurse !== undefined) {
+      if (propConfig.cfRecurse !== '') {
+        throw new ReferenceError(errors.RECURSE_TARGET);
+      }
       example = this.extract(schema, schema);
     } else if (propConfig.type === 'array' && propConfig.items && !example) {
       if (propConfig.items.example) {

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -6,13 +6,8 @@ var curl = require('./curl');
 var JSONformatter = require('./json');
 var exampleExtractor = require('./example-data-extractor');
 var ObjectDefinition = require('./object-definition');
+var errors = require('./errors');
 var pointer = require('./pointer');
-
-var throwError = function(e, msg) {
-  var err = new Error(msg + ': ' + e.message);
-  err.stack = e.stack;
-  throw err;
-};
 
 /**
  * Extend a schema with composed data for rendering in a template
@@ -85,7 +80,7 @@ var transformLink = function(schema, link, options) {
       ['schema', 'targetSchema']
     );
   } catch (e) {
-    throwError('Error building link for ' + schema.id, e);
+    errors.throwError('Error building link for ' + schema.id, e);
   }
 };
 
@@ -110,7 +105,7 @@ var buildHref = function(href, schema, withExampleData) {
       // Resolve the reference within the schema
       var definition = pointer.get(schema, stripped.substring(1));
       if (!definition) {
-        throwError(e, 'Could not resolve href: ' + href);
+        errors.throwError(e, 'Could not resolve href: ' + href);
       }
       // Replace the match with either example data or the last component of the pointer
       var replacement = withExampleData ? exampleExtractor.getExampleDataFromItem(definition) : ':' + path.basename(stripped);
@@ -118,7 +113,7 @@ var buildHref = function(href, schema, withExampleData) {
       return str.replace(match, replacement);
     }, href);
   } catch (e) {
-    throwError(e, 'Could not build href: ' + href);
+    errors.throwError(e, 'Could not build href: ' + href);
   }
 };
 
@@ -185,8 +180,10 @@ var generateExample = function(component, root) {
  */
 var formatLinkParameters = function(schema, root) {
   var baseSchema = root;
-  if (schema.rel !== 'self') {
+  if (schema.cfRecurse === undefined) {
     baseSchema = schema;
+  } else if (schema.cfRecurse !== '') {
+    throw new ReferenceError(errors.RECURSE_TARGET);
   }
   return generateObjectDefinition(baseSchema);
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -136,8 +136,8 @@ var buildCurl = function (link, schema, options) {
   if (_.get(options, 'curl.requestHeaders')) {
     headers = exampleExtractor.extract(_.get(options, 'curl.requestHeaders'), schema);
   }
-  if (link.requestHeaders) {
-    headers = exampleExtractor.extract(link.requestHeaders, schema);
+  if (link.cfRequestHeaders) {
+    headers = exampleExtractor.extract(link.cfRequestHeaders, schema);
   }
 
   var data = link.schemaExampleData;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-example-loader",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "description": "Webpack loader that transforms JSON HyperSchema (without $refs) into examples.",
   "main": "lib/loader.js",
   "scripts": {

--- a/test/example-data-extractor.js
+++ b/test/example-data-extractor.js
@@ -61,10 +61,10 @@ describe('Example Data Extractor', function() {
       expect(this.example.composite).to.have.property('attribute_two').that.equals(2);
     });
 
-    it('should resolve rel=self references', function() {
+    it('should resolve cfRecurse references', function() {
       var obj = extractor.mapPropertiesToExamples({
         key: {
-          rel: 'self'
+          cfRecurse: ''
         }
       }, this.schema1);
       expect(obj).to.be.an('object');
@@ -117,10 +117,10 @@ describe('Example Data Extractor', function() {
       expect(this.example).to.have.property('option').that.has.key('attribute_two');
     });
 
-    it('should resolve rel=self references', function() {
+    it('should resolve cfRecurse', function() {
       expect(extractor.extract({
         key: {
-          rel: 'self'
+          cfRecurse: ''
         }
       }, this.schema1)).to.be.an('object');
     });

--- a/test/fixtures/schema1.json
+++ b/test/fixtures/schema1.json
@@ -193,7 +193,7 @@
             }
           },
           "targetSchema": {
-            "rel": "self"
+            "cfRecurse": ""
           }
         },
         {
@@ -201,7 +201,7 @@
           "href": "/fixtures/bazzes/{#/definitions/identifier}",
           "method": "GET",
           "targetSchema": {
-            "rel": "self"
+            "cfRecurse": ""
           }
         }
       ]
@@ -243,7 +243,7 @@
         }
       },
       "targetSchema": {
-        "rel": "self"
+        "cfRecurse": ""
       }
     },
     {
@@ -251,7 +251,7 @@
       "href": "/fixtures/foos/{#/definitions/identifier}",
       "method": "GET",
       "targetSchema": {
-        "rel": "self"
+        "cfRecurse": ""
       }
     },
     {
@@ -296,7 +296,7 @@
         }
       },
       "targetSchema": {
-        "rel": "self"
+        "cfRecurse": ""
       }
     },
     {
@@ -317,7 +317,7 @@
         "minItems": 2,
         "maxItems": 5,
         "items": {
-          "rel": "self"
+          "cfRecurse": ""
         }
       }
     }

--- a/test/fixtures/schema2.json
+++ b/test/fixtures/schema2.json
@@ -47,7 +47,7 @@
         }
       },
       "targetSchema": {
-        "rel": "self"
+        "cfRecurse": ""
       }
     },
     {
@@ -55,7 +55,7 @@
       "href": "/fixtures/bazzes/{#/definitions/identifier}",
       "method": "GET",
       "targetSchema": {
-        "rel": "self"
+        "cfRecurse": ""
       }
     }
   ]

--- a/test/transformer.js
+++ b/test/transformer.js
@@ -123,7 +123,7 @@ describe('Schema Transformer', function() {
       expect(this.example.nested_object).to.not.be.empty;
     });
 
-    it('should handle rel=self references', function() {
+    it('should handle cfRecurse references', function() {
       var data = transformer.generateExample(this.schema1.links[0].targetSchema, this.schema1);
       expect(data).to.be.an('object');
       expect(data).to.deep.equal({
@@ -148,34 +148,35 @@ describe('Schema Transformer', function() {
         },
         plus_one: 'bar'
       });
+    });
 
-        it('should handle rel=self references as an array', function() {
-          var data = this.transformer.generateExample(this.schema1.links[3].targetSchema, this.schema1);
-          expect(data).to.be.an('array');
-          expect(data.length).to.be.gte(2);
-          expect(data.length).to.be.lte(5);
-          expect(data[0]).to.deep.equal({
-            id: 123,
-            foo: 'bar',
-            baz: 'boo',
-            array_prop: ['bar'],
-            boo: {
-              attribute_one: 'One'
-            },
-            nested_object: {
-              baz: 'boo',
-              foo: 'bar'
-            },
-            composite: {
-              attribute_one: 'One',
-              attribute_two: 2
-            },
-            option: {
-              attribute_two: 2
-            },
-            plus_one: 'bar'
-          });
-        });
+    it('should handle cfRecurse references as an array', function() {
+      var data = transformer.generateExample(this.schema1.links[3].targetSchema, this.schema1);
+      expect(data).to.be.an('array');
+      expect(data.length).to.be.gte(2);
+      expect(data.length).to.be.lte(5);
+      expect(data[0]).to.deep.equal({
+        id: 123,
+        ID: 'something',
+        foo: 'bar',
+        baz: 'boo',
+        array_prop: ['bar'],
+        boo: {
+          attribute_one: 'One'
+        },
+        nested_object: {
+          baz: 'boo',
+          foo: 'bar'
+        },
+        composite: {
+          attribute_one: 'One',
+          attribute_two: 2
+        },
+        option: {
+          attribute_two: 2
+        },
+        plus_one: 'bar'
+      });
     });
   });
 });


### PR DESCRIPTION
This starts to move along the [ROADMAP](https://github.com/cloudflare/doca/blob/master/ROADMAP.md) by namespacing most of the custom keywords with a `cf` prefix.  For the keywords examined by the example-loader, they were already either single words or camelCase.  The prefixed keywords are camelCase to match JSON Schema.

Note that some extension keywords recognized by the theme are not handled in the example-loader.  There is not yet a revision of the doca-bootstrap-them to make use of example-loader 2.0 or 3.0, but a new or revised theme will be forthcoming.

See the commit comments for exactly what has and has not been changed, and why.
