### PR TITLE
Support link mediaType and encType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## v3.1.0
+
+* Support added for "encType" and "mediaType" with raw string examples.
+
 ## v3.0.0
 
 * The non-standard usage of "rel": "self" has been changed to a new

--- a/lib/curl.js
+++ b/lib/curl.js
@@ -41,10 +41,13 @@ module.exports = {
     }
 
     if (data && method.toLowerCase() !== 'get') {
-      if (encType === 'multipart/form-data') {
+      if (encType === undefined || encType.match(this.formatter.jsonMediaType)) {
+        flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
+      } else if (encType === 'multipart/form-data') {
         flags.push(this.buildFlag('-form', this.formatForm(data), 5, '"'));
       } else {
-        flags.push(this.buildFlag('-data', this.formatData(data), 5, '\''));
+        // The non-JSON, non-multipart data is a raw string.  Do not format it.
+        flags.push(this.buildFlag('-data', data));
       }
     }
 

--- a/lib/example-data-extractor.js
+++ b/lib/example-data-extractor.js
@@ -20,10 +20,10 @@ var ExampleDataExtractor = function() {};
  */
 ExampleDataExtractor.prototype.extract = function(component, root) {
   var reduced = {};
-
   if (!component) {
     throw new ReferenceError('No schema received to generate example data');
   }
+
   // If the schema defines an ID, change scope so all local references as resolved
   // relative to the schema with the closest ID
   if (component.id) {
@@ -56,7 +56,15 @@ ExampleDataExtractor.prototype.extract = function(component, root) {
     _.range(_.random(minItems, maxItems)).forEach(function(i) {
       reduced.push( this.extract(component.items, root) );
     }.bind(this));
+
+  } else if (component.example) {
+    // If we do not recognize the type of component, see if it has pre-set
+    // example defined.  This is particularly useful for link schemas
+    // with non-JSON link payloads (e.g. "mediaType" and "encType" keywords),
+    // as it is the only way to produce a top-level string example.
+    reduced = component.example;
   }
+
   // Optionally merge in extra properties
   // @TODO: Determine if this is the right thing to do
   if (_.has(component, 'extraProperties') && _.get(component, 'generator.includeExtraProperties')) {

--- a/lib/json.js
+++ b/lib/json.js
@@ -11,6 +11,7 @@ var DEFAULTS = {
  * @class JSONFormatter
  * @module lib/formatters/json
  * @type {{format: Function}}
+ * @type {{jsonMediaType: RegExp}}
  */
 module.exports = {
   /**
@@ -23,5 +24,6 @@ module.exports = {
     replacer = !_.isUndefined(replacer) ? replacer : DEFAULTS.replacer;
     space = !_.isUndefined(space) ? space : DEFAULTS.space;
     return JSON.stringify(data, replacer, space);
-  }
+  },
+  jsonMediaType: /^application\/(.*\+)?json$/
 };

--- a/lib/transformer.js
+++ b/lib/transformer.js
@@ -69,13 +69,25 @@ var transformLinks = function(schema, links, options) {
  */
 var transformLink = function(schema, link, options) {
   try {
+    var response;
+    if (link.targetSchema) {
+      response = generateExample(link.targetSchema, schema);
+
+      // We only want to format JSON example data, which is the default.
+      // The analogous request example logic is in the curl module.
+      if (link.mediaType === undefined ||
+          link.mediaType.match(JSONformatter.jsonMediaType)) {
+        response = formatData(response);
+      }
+    }
+
     return _.omit(
       _.extend(link, {
         html_id: _sanitizeHTMLID(schema.title + '-' + link.title),
         uri: buildHref(link.href, schema),
         curl: buildCurl(link, schema, options),
         parameters: link.schema ? formatLinkParameters(link.schema, schema) : undefined,
-        response: link.targetSchema ? formatData(generateExample(link.targetSchema, schema)) : undefined
+        response: response
       }),
       ['schema', 'targetSchema']
     );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "json-schema-example-loader",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "Webpack loader that transforms JSON HyperSchema (without $refs) into examples.",
   "main": "lib/loader.js",
   "scripts": {

--- a/test/fixtures/schema2.json
+++ b/test/fixtures/schema2.json
@@ -57,6 +57,19 @@
       "targetSchema": {
         "cfRecurse": ""
       }
+    },
+    {
+      "title": "Do a thing with a script",
+      "href": "/fixtures/scripts",
+      "method": "POST",
+      "encType": "application/javascript",
+      "schema": {
+        "example": "hello('world');"
+      },
+      "mediaType": "application/javascript",
+      "targetSchema": {
+        "example": "hello('back');"
+      }
     }
   ]
 }

--- a/test/transformer.js
+++ b/test/transformer.js
@@ -53,6 +53,13 @@ describe('Schema Transformer', function() {
       expect(this.link).to.have.property('parameters').that.is.an('object');
       expect(this.link).to.have.property('parameters').that.is.an.instanceOf(ObjectDefinition);
     });
+
+    it('should handle non-JSON media types', function() {
+      var mediaLink = transformer.transformLink(this.schema2, this.schema2.links[2]);
+
+      expect(mediaLink.curl).to.match(/\n--data \"hello\('world'\);\"$/);
+      expect(mediaLink.response).to.equal("hello('back');");
+    });
   });
 
   describe('#buildHref', function() {


### PR DESCRIPTION
APIs can send other content types such as XML, JavaScript files
and many other things as requests and responses.

Currently, we only support application/json (the default) and
multipart/form-data (which has a special syntax for curl).

This adds support for any other media type, with the expectation
that, when "encType" or "mediaType" is used this way,
"schema" or "targetSchema" (respectively) will only have
an "example" field with a pre-formatted string.

We detect these situations and avoid passing the example through
the JSON formatter.  This required a recognizing example-only
schemas directly, as they would otherwise produce an empty
object example (the default behavior of the old code).